### PR TITLE
fix GPG_TTY initialization

### DIFF
--- a/terminal/zshell/zsh_env
+++ b/terminal/zshell/zsh_env
@@ -12,6 +12,6 @@ export EDITOR="nvim"
 export LC_ALL=en_US.UTF-8
 export LANG=en_US.UTF-8
 # for gpg
-export GPG_TTY=$(tty)
+export GPG_TTY=$TTY
 # for last pass no never end session after login
 export LPASS_AGENT_TIMEOUT=0

--- a/terminal/zshell/zsh_functions
+++ b/terminal/zshell/zsh_functions
@@ -27,9 +27,3 @@ function git_current_branch() {
   fi
   echo ${ref#refs/heads/}
 }
-
-# workaround to resolve 'is not tty' issue
-function gpg() {
-  export GPG_TTY=$(tty)
-  /usr/local/bin/gpg "$@"
-}

--- a/terminal/zshell/zshrc
+++ b/terminal/zshell/zshrc
@@ -8,7 +8,6 @@ fi
 # zmodload zsh/zprof
 source $HOME/.zsh_env
 source $HOME/.zsh_prompt
-echo $(tty)
 source $HOME/.zsh_settings
 source $HOME/.zsh_langs
 source $HOME/.zsh_plugins


### PR DESCRIPTION
Zsh sets TTY parameter to point to the TTY used by the shell. For comparison, `tty` command line tool checks whether stdin is a TTY and prints its name if it is. In many cases the only difference between `$TTY` and `$(tty)` is performance (the former is 1000+ times faster). However, if stdin is redirected, `$TTY` still works while `$(tty)` will either fail or give incorrect answer. For example:

```zsh
PROMPT= zsh -dfis <<<'print -lr -- TTY=$TTY tty="$(tty 2>&1)"'
```

Output:

```text
TTY=/dev/pts/0
tty=not a tty
```

Another example where `tty` fails is when Powerlevel10k instant prompt is active. See: https://github.com/romkatv/powerlevel10k#how-do-i-enable-instant-prompt.